### PR TITLE
fetch latest ocserv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ MAINTAINER Wyatt Pan <wppurking@gmail.com>
 RUN apt-get update
 RUN apt-get install build-essential libwrap0-dev libpam0g-dev libdbus-1-dev libreadline-dev libnl-route-3-dev libprotobuf-c0-dev libpcl1-dev libopts25-dev autogen libgnutls28 libgnutls28-dev libseccomp-dev iptables wget gnutls-bin -y
 
-RUN cd /root && wget ftp://ftp.infradead.org/pub/ocserv/ocserv-0.8.2.tar.xz && tar xvf /root/ocserv-0.8.2.tar.xz && cd ocserv-0.8.2 && ./configure --prefix=/usr --sysconfdir=/etc && make && make install;rm -rf /root/*
+RUN cd /root && wget http://www.infradead.org/ocserv/download.html && export ocserv_version=$(cat download.html | grep -o '[0-9]\.[0-9]\.[0-9]') \
+	&& wget ftp://ftp.infradead.org/pub/ocserv/ocserv-$ocserv_version.tar.xz && tar xvf ocserv-$ocserv_version.tar.xz \
+	&& cd ocserv-$ocserv_version && ./configure --prefix=/usr --sysconfdir=/etc && make && make install \
+	&& rm -rf /root/*
 
 ADD ./certs /opt/certs
 RUN certtool --generate-privkey --outfile /opt/certs/ca-key.pem


### PR DESCRIPTION
自动获取最新版本的ocserv，这样你不用修改代码，就可以通过[docker hub](https://registry.hub.docker.com/u/wppurking/ocserv-docker/)来进行版本控制了：
    1. 取消`automated build settings`中的`active`选项，即手动`start a build`
    2. 有新版本ocserv时，在`automated build settings`中，除了latest标签外，添加一个ocserv版本号的标签，删除旧版本标签
    3. 最后手动`start a build` 
