### PR TITLE
create tun device and allow command line args

### DIFF
--- a/bin/vpn_run
+++ b/bin/vpn_run
@@ -5,7 +5,13 @@
 #
 
 # open ipv4 ip forward
-sysctl -w net.ipv4.ip_forward=1 && sysctl -p
+sysctl -w net.ipv4.ip_forward=1
+
+if [ ! -e /dev/net/tun ]; then
+	mkdir -p /dev/net
+	mknod /dev/net/tun c 10 200
+	chmod 600 /dev/net/tun
+fi
 
 # open iptables nat
 iptables -t nat -A POSTROUTING -j MASQUERADE
@@ -13,4 +19,4 @@ iptables -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 # run it
 #ocserv -c /etc/ocserv/ocserv.conf -f -d 1
-ocserv -c /etc/ocserv/ocserv.conf -f
+ocserv -c /etc/ocserv/ocserv.conf -f $@


### PR DESCRIPTION
Ubtuntu container has no /dev/net/tun file in it (at least in my linode)
so we create it.

Add a `$@` to ocserv command to accept command line args.
