### PR TITLE
Add libev4 and libev-dev packages for ocserv-0.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD ./bin /usr/local/bin
 RUN chmod a+x /usr/local/bin/*
 WORKDIR /etc/ocserv
 
-RUN apt-get update && apt-get install build-essential libwrap0-dev libpam0g-dev libdbus-1-dev libreadline-dev libnl-route-3-dev  libpcl1-dev libopts25-dev autogen libgnutls28 libgnutls28-dev libseccomp-dev iptables wget gnutls-bin libprotobuf-c0-dev protobuf-c-compiler libprotobuf-dev protobuf-compiler libprotoc-dev libtalloc-dev libhttp-parser-dev -y
+RUN apt-get update && apt-get install build-essential libwrap0-dev libpam0g-dev libdbus-1-dev libreadline-dev libnl-route-3-dev  libpcl1-dev libopts25-dev autogen libgnutls28 libgnutls28-dev libseccomp-dev iptables wget gnutls-bin libprotobuf-c0-dev protobuf-c-compiler libprotobuf-dev protobuf-compiler libprotoc-dev libtalloc-dev libhttp-parser-dev libev4 libev-dev -y
 
 
 RUN cd /root && wget http://www.infradead.org/ocserv/download.html && export ocserv_version=$(cat download.html | grep -o '[0-9]*\.[0-9]*\.[0-9]*') \


### PR DESCRIPTION
The latest version ocserv-0.11.2 will break during configure with the following errors:

```
checking for libev... no
configure: error: ***
*** libev4 was not found.
***
```

Adding these two packages will solve the problem.