### PR TITLE
添加了 dnsmasq 和 radcli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,13 @@ RUN mkdir -p /temp && cd /temp \
     && make && make install \
     && cd / && rm -rf /temp
 
-
+RUN cd /opt/certs && ls \
+    && ca_cn=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) && bash -c "sed -i 's/Your desired authority name/$ca_cn/g' /opt/certs/ca-tmp" \
+    && ca_org=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) && bash -c "sed -i 's/Your desired orgnization name/$ca_org/g' /opt/certs/ca-tmp" \
+    && serv_domain=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-12} | head -n 1) && bash -c -i "sed -i 's/yourdomainname/$serv_domain/g' /opt/certs/serv-tmp" \
+    && serv_org=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) && bash -c "sed -i 's/Your desired orgnization name/$serv_org/g' /opt/certs/serv-tmp" \
+    && user_id=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-10} | head -n 1) && bash -c "sed -i 's/user/$user_id/g' /opt/certs/user-tmp" \
+    
     # generate [ca-key.pem] -> ca-cert.pem [ca-key]
     && certtool --generate-privkey --outfile /opt/certs/ca-key.pem && certtool --generate-self-signed --load-privkey /opt/certs/ca-key.pem --template /opt/certs/ca-tmp --outfile /opt/certs/ca-cert.pem \
     # generate [server-key.pem] -> server-cert.pem [ca-key, server-key] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,26 +3,66 @@ MAINTAINER Wyatt Pan <wppurking@gmail.com>
 
 ADD ./certs /opt/certs
 ADD ./bin /usr/local/bin
+ADD dnsmasq.conf /dnsmasq.conf
 RUN chmod a+x /usr/local/bin/*
 WORKDIR /etc/ocserv
 
-RUN apt-get update && apt-get install build-essential wget xz-utils libgnutls28-dev gnutls-bin libev-dev libwrap0-dev libpam0g-dev libseccomp-dev libreadline-dev libnl-route-3-dev libkrb5-dev liboath-dev libprotobuf-c0-dev libtalloc-dev libhttp-parser-dev libpcl1-dev libopts25-dev autogen pkg-config nettle-dev protobuf-c-compiler gperf liblockfile-bin nuttcp lcov iptables -y
+# china timezone
+RUN echo "Asia/Shanghai" > /etc/timezone \
+    && dpkg-reconfigure -f noninteractive tzdata
 
+# install compiler, dependencies, tools , dnsmasq
+RUN apt-get update && apt-get install -y \
+    build-essential wget xz-utils libgnutls28-dev \
+    libev-dev libwrap0-dev libpam0g-dev libseccomp-dev libreadline-dev \
+    libnl-route-3-dev libkrb5-dev liboath-dev libprotobuf-c0-dev libtalloc-dev \
+    libhttp-parser-dev libpcl1-dev libopts25-dev autogen pkg-config nettle-dev \
+    protobuf-c-compiler gnutls-bin gperf liblockfile-bin nuttcp lcov iptables \
+    unzip dnsmasq \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN cd /root && wget https://github.com/Cyan4973/lz4/releases/latest -o lz4.html && export lz4_version=$(cat lz4.html | grep -m 1 -o 'r[0-9][0-9][0-9]') \
-	&& wget https://github.com/Cyan4973/lz4/archive/$lz4_version.tar.gz && tar xvf $lz4_version.tar.gz && cd lz4-$lz4_version && make install && ln -sf /usr/local/lib/liblz4.* /usr/lib/ \
-	&& wget http://www.infradead.org/ocserv/download.html && export ocserv_version=$(cat download.html | grep -o '[0-9]*\.[0-9]*\.[0-9]*') \
-	&& cd /root && wget ftp://ftp.infradead.org/pub/ocserv/ocserv-$ocserv_version.tar.xz && tar xvf ocserv-$ocserv_version.tar.xz \
-	&& cd ocserv-$ocserv_version && sed -i 's/define DEFAULT_CONFIG_ENTRIES 96/define DEFAULT_CONFIG_ENTRIES 200/g' src/vpn.h  \
-    && ./configure --prefix=/usr --sysconfdir=/etc --with-local-talloc && make && make install \
-	&& rm -rf /root/*
+# configuration dnsmasq
+RUN mkdir -p /temp && cd /temp \
+    && wget https://github.com/felixonmars/dnsmasq-china-list/archive/master.zip \
+    && unzip master.zip \
+    && cd dnsmasq-china-list-master \
+    && cp *.conf /etc/dnsmasq.d/ \
+    && bash dnsmasq-update-china-list cnnic \
+    && cd / && rm -rf /temp
 
-RUN cd /opt/certs && ls \
-    && ca_cn=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) && bash -c "sed -i 's/Your desired authority name/$ca_cn/g' /opt/certs/ca-tmp" \
-    && ca_org=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) && bash -c "sed -i 's/Your desired orgnization name/$ca_org/g' /opt/certs/ca-tmp" \
-    && serv_domain=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-12} | head -n 1) && bash -c -i "sed -i 's/yourdomainname/$serv_domain/g' /opt/certs/serv-tmp" \
-    && serv_org=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1) && bash -c "sed -i 's/Your desired orgnization name/$serv_org/g' /opt/certs/serv-tmp" \
-    && user_id=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-10} | head -n 1) && bash -c "sed -i 's/user/$user_id/g' /opt/certs/user-tmp" \
+# configuration lz4
+RUN mkdir -p /temp && cd /temp \
+    && wget https://github.com/Cyan4973/lz4/releases/latest -O lz4.html \
+    && export lz4_version=$(cat lz4.html | grep -m 1 -o 'r[0-9][0-9][0-9]') \
+    && wget https://github.com/Cyan4973/lz4/archive/$lz4_version.tar.gz \
+    && tar xvf $lz4_version.tar.gz \
+    && cd lz4-$lz4_version \
+    && make install \
+    && ln -sf /usr/local/lib/liblz4.* /usr/lib/ \
+    && cd / && rm -rf /temp
+
+# configuration radcli
+RUN mkdir -p /temp && cd /temp \
+    && wget https://github.com/radcli/radcli/releases/latest -O radcli.html \
+    && export radcli_version=$(cat radcli.html | grep -m 1 -o '[0-9]\.[0-9]\.[0-9]') \
+    && wget https://github.com/radcli/radcli/releases/download/$radcli_version/radcli-$radcli_version.tar.gz \
+    && tar xzf radcli-$radcli_version.tar.gz \
+    && cd radcli-$radcli_version \
+    && ./configure --prefix=/usr --sysconfdir=/etc --enable-legacy-compat \
+    && make && make install \
+    && cd / && rm -rf /temp
+
+# configuration ocserv
+RUN mkdir -p /temp && cd /temp \
+    && wget http://www.infradead.org/ocserv/download.html \
+    && export ocserv_version=$(cat download.html | grep -o '[0-9]*\.[0-9]*\.[0-9]*') \
+    && wget ftp://ftp.infradead.org/pub/ocserv/ocserv-$ocserv_version.tar.xz \
+    && tar xvf ocserv-$ocserv_version.tar.xz \
+    && cd ocserv-$ocserv_version \
+    && ./configure --prefix=/usr --sysconfdir=/etc --with-local-talloc \
+    && make && make install \
+    && cd / && rm -rf /temp
+
 
     # generate [ca-key.pem] -> ca-cert.pem [ca-key]
     && certtool --generate-privkey --outfile /opt/certs/ca-key.pem && certtool --generate-self-signed --load-privkey /opt/certs/ca-key.pem --template /opt/certs/ca-tmp --outfile /opt/certs/ca-cert.pem \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Wyatt Pan <wppurking@gmail.com>
 
 ADD ./certs /opt/certs
 ADD ./bin /usr/local/bin
-ADD dnsmasq.conf /dnsmasq.conf
+ADD dnsmasq.conf /usr/local/etc/dnsmasq.conf
 RUN chmod a+x /usr/local/bin/*
 WORKDIR /etc/ocserv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN mkdir -p /temp && cd /temp \
     && unzip master.zip \
     && cd dnsmasq-china-list-master \
     && cp *.conf /etc/dnsmasq.d/ \
-    && bash dnsmasq-update-china-list cnnic \
     && cd / && rm -rf /temp
 
 # configuration lz4

--- a/bin/vpn_run
+++ b/bin/vpn_run
@@ -5,7 +5,7 @@
 #
 
 # start dnsmasq
-dnsmasq -C /dnsmasq.conf
+dnsmasq -C /usr/local/etc/dnsmasq.conf
 
 
 # open ipv4 ip forward

--- a/bin/vpn_run
+++ b/bin/vpn_run
@@ -4,6 +4,10 @@
 # Run the OpenConnect server normally
 #
 
+# start dnsmasq
+dnsmasq -C /dnsmasq.conf
+
+
 # open ipv4 ip forward
 sysctl -w net.ipv4.ip_forward=1
 

--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -1,0 +1,6 @@
+no-resolv
+no-poll
+server=8.8.8.8
+listen-address=0.0.0.0
+bind-interfaces
+conf-dir=/etc/dnsmasq.d/

--- a/ocserv/ocserv.conf
+++ b/ocserv/ocserv.conf
@@ -429,8 +429,9 @@ ipv4-netmask = 255.255.255.0
 # multiple servers.
 # dns = fc00::4be0
 #dns = 192.168.1.2
-dns = 8.8.8.8
-dns = 8.8.4.4
+#dns = 8.8.8.8
+#dns = 8.8.4.4
+dns = 10.0.0.1
 
 # The NBNS server (if any)
 #nbns = 192.168.1.3

--- a/ocserv/ocserv.conf
+++ b/ocserv/ocserv.conf
@@ -405,8 +405,8 @@ predictable-ips = true
 # Note that, you could use addresses from a subnet of your LAN network if you
 # enable proxy arp in the LAN interface (see http://infradead.org/ocserv/recipes-ocserv-pseudo-bridge.html);
 # in that case it is recommended to set ping-leases to true.
-ipv4-network = 10.10.10.0
-ipv4-netmask = 255.255.255.0
+ipv4-network = 10.0.0.0
+ipv4-netmask = 255.0.0.0
 
 # An alternative way of specifying the network:
 #ipv4-network = 192.168.1.0/24
@@ -428,7 +428,6 @@ ipv4-netmask = 255.255.255.0
 # The advertized DNS server. Use multiple lines for
 # multiple servers.
 # dns = fc00::4be0
-#dns = 192.168.1.2
 #dns = 8.8.8.8
 #dns = 8.8.4.4
 dns = 10.0.0.1
@@ -479,7 +478,6 @@ output-buffer = 20
 
 # ------ route 与 no-route 只能选一个 ------
 # 让 server 所在的服务器也不走路由(可 ssh).
-#no-route = 123.123.123.0/255.255.255.0
 no-route = 192.168.0.0/255.255.0.0
 no-route = 1.0.0.0/255.192.0.0
 no-route = 1.64.0.0/255.224.0.0
@@ -650,8 +648,7 @@ no-route = 183.0.0.0/255.192.0.0
 no-route = 183.64.0.0/255.224.0.0
 no-route = 183.128.0.0/255.128.0.0
 no-route = 192.124.154.0/255.255.255.0
-no-route = 192.140.0.0/255.255.0.0
-no-route = 192.188.170.0/255.255.255.0
+no-route = 192.140.128.0/255.255.128.0
 no-route = 202.0.0.0/255.128.0.0
 no-route = 202.128.0.0/255.192.0.0
 no-route = 202.192.0.0/255.224.0.0


### PR DESCRIPTION
添加 dnsmasq 可以让客户端使用 服务器端做 dns 服务器
其中使用了 https://github.com/felixonmars/dnsmasq-china-list 来做区分国内外的域名
国内域名使用 cnnic 解析，国外域名使用 8.8.8.8 解析
这样避免了所有解析都发往 8.8.8.8 造成的某些国内服务被解析到国外的 CDN
同时保证了国外服务会被解析到服务器最近的 CDN

添加 radcli 可以让 ocserv 使用 RADIUS  验证