### PR TITLE
Update ocserv download page link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p /temp && cd /temp \
 
 # configuration ocserv
 RUN mkdir -p /temp && cd /temp \
-    && wget http://www.infradead.org/ocserv/download.html \
+    && wget https://ocserv.gitlab.io/www/download.html \
     && export ocserv_version=$(cat download.html | grep -o '[0-9]*\.[0-9]*\.[0-9]*') \
     && wget ftp://ftp.infradead.org/pub/ocserv/ocserv-$ocserv_version.tar.xz \
     && tar xvf ocserv-$ocserv_version.tar.xz \


### PR DESCRIPTION
发现 `ocserv` 的下载地址换到了新的页面上去了 现在这个地址自己构建的时候不成功(获取不到版本号)